### PR TITLE
✨ [홈 페이지] 레이아웃 구성 / 디자인 적용 (UT 버전)

### DIFF
--- a/components/carousel/Carousel.style.tsx
+++ b/components/carousel/Carousel.style.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 const CarouselWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  margin: 0;
   width: 100%;
   overflow-x: scroll;
   user-select: none;

--- a/domains/webtoon/home/Genres.style.tsx
+++ b/domains/webtoon/home/Genres.style.tsx
@@ -3,16 +3,16 @@ import styled from '@emotion/styled';
 const GenresWrapper = styled.div`
   display: flex;
   gap: 1.2rem;
-  margin: 0;
 `;
 
 const CarouselBox = styled.div`
   display: flex;
   flex-direction: column;
   border-radius: 40px;
+  border-radius: 16px;
   background-color: ${(props) => props.theme.bg_color.primary};
-  width: 80px;
-  height: 80px;
+  width: 144px;
+  height: 115px;
 `;
 
 export { GenresWrapper, CarouselBox };

--- a/domains/webtoon/home/Home.style.tsx
+++ b/domains/webtoon/home/Home.style.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 // TODO: 공통 레이아웃으로 변경
 const DefaultLayout = styled.div`
-  min-width: 320px;
   max-width: 1024px;
   height: 100vh;
 `;
@@ -19,18 +18,24 @@ const DefaultHeader = styled.header`
 const HomeContainer = styled.main``;
 
 const HomeTopWrapper = styled.section`
-  width: 100%;
+  padding: ${(props) => props.theme.padding.layout};
+  padding-top: 0.8rem;
 `;
 
 const HomeTopTitleWrapper = styled.div`
   display: inline-block;
   align-items: flex-start;
-  padding: ${(props) => props.theme.padding.layout};
-  padding-top: 2rem;
+  padding-top: 0.8rem;
   height: 200px;
 `;
 
+const HomeTopSubTitle = styled.span`
+  font-size: 1.6rem;
+  font-weight: 500;
+`;
+
 const HomeTopTitle = styled.h1`
+  padding-top: 0.4rem;
   width: 200px;
   font-size: 2.4rem;
   font-weight: bold;
@@ -41,15 +46,42 @@ const HomeSectionWrapper = styled.section`
   padding-top: 3rem;
 `;
 
+const HomeSectionSubTitle = styled.small`
+  color: ${(props) => props.theme.colors.grey_400};
+  font-size: 1.2rem;
+`;
+
+const HomeSectionTitleWithTimeWrapper = styled.div`
+  display: flex;
+  align-items: baseline;
+  padding: 0.6rem 0 1.6rem;
+
+  > header {
+    padding: unset;
+  }
+`;
+
 const HomeSectionTitle = styled.header`
-  margin-bottom: 1.6rem;
+  padding: 0.6rem 0 1.6rem;
   font-size: 2.4rem;
   font-weight: bold;
 `;
 
-const HomeSectionSubTitle = styled.small`
-  color: ${(props) => props.theme.colors.grey_400};
+const HomeSectionTitleWithTime = styled.span`
+  padding-left: 0.6rem;
+  color: ${(props) => props.theme.colors.grey_500};
   font-size: 1.2rem;
+`;
+
+const HomeRecommendationWrapper = styled.section`
+  padding: 3rem 0;
+`;
+
+const HomeRecommendationBackground = styled.div`
+  background-color: #f5f7fa;
+  padding: ${(props) => props.theme.padding.layout_carousel};
+  padding-top: 3rem;
+  padding-bottom: 3rem;
 `;
 
 export {
@@ -58,8 +90,13 @@ export {
   HomeContainer,
   HomeTopWrapper,
   HomeTopTitleWrapper,
+  HomeTopSubTitle,
   HomeTopTitle,
   HomeSectionWrapper,
-  HomeSectionTitle,
   HomeSectionSubTitle,
+  HomeSectionTitleWithTimeWrapper,
+  HomeSectionTitle,
+  HomeSectionTitleWithTime,
+  HomeRecommendationWrapper,
+  HomeRecommendationBackground,
 };

--- a/domains/webtoon/home/Home.tsx
+++ b/domains/webtoon/home/Home.tsx
@@ -7,10 +7,15 @@ import {
   HomeContainer,
   HomeTopWrapper,
   HomeTopTitleWrapper,
+  HomeTopSubTitle,
   HomeTopTitle,
   HomeSectionWrapper,
-  HomeSectionTitle,
   HomeSectionSubTitle,
+  HomeSectionTitleWithTimeWrapper,
+  HomeSectionTitle,
+  HomeSectionTitleWithTime,
+  HomeRecommendationWrapper,
+  HomeRecommendationBackground,
 } from './Home.style';
 import RealTimeChart from './RealTimeChart';
 import Genres from './Genres';
@@ -36,41 +41,47 @@ function Home() {
         <HomeContainer>
           <HomeTopWrapper>
             <HomeTopTitleWrapper>
-              <HomeTopTitle>개미는 오늘도 열심히 툰툰을 보네</HomeTopTitle>
+              <HomeTopSubTitle>열심히일하는일개미님</HomeTopSubTitle>
+              <HomeTopTitle>오늘은 어떤 웹툰에 탑승할까요?</HomeTopTitle>
             </HomeTopTitleWrapper>
-            <HomeSectionWrapper>
-              <HomeSectionSubTitle>14:00</HomeSectionSubTitle>
-              <HomeSectionTitle>실시간 차트</HomeSectionTitle>
-              <Carousel ref={RealTimeChartRef}>
-                <RealTimeChart />
-              </Carousel>
-            </HomeSectionWrapper>
           </HomeTopWrapper>
           <HomeSectionWrapper>
-            <HomeSectionSubTitle>어떤 장르를 좋아하시나요?</HomeSectionSubTitle>
+            <HomeSectionSubTitle>다같이 영차영차</HomeSectionSubTitle>
+            <HomeSectionTitleWithTimeWrapper>
+              <HomeSectionTitle>실시간 차트</HomeSectionTitle>
+              <HomeSectionTitleWithTime>14:00 기준</HomeSectionTitleWithTime>
+            </HomeSectionTitleWithTimeWrapper>
+            <Carousel ref={RealTimeChartRef}>
+              <RealTimeChart />
+            </Carousel>
+          </HomeSectionWrapper>
+          <HomeSectionWrapper>
+            <HomeSectionSubTitle>어떤 장르가 좋을까?</HomeSectionSubTitle>
             <HomeSectionTitle>장르별 툰툰</HomeSectionTitle>
             <Carousel ref={GenresRef}>
               <Genres />
             </Carousel>
           </HomeSectionWrapper>
           <HomeSectionWrapper>
-            <HomeSectionSubTitle>언제나 툰툰</HomeSectionSubTitle>
-            <HomeSectionTitle>개미들이 즐겨봐요</HomeSectionTitle>
+            <HomeSectionSubTitle>상한가 열차 탑승!</HomeSectionSubTitle>
+            <HomeSectionTitle>상승 중인 툰툰</HomeSectionTitle>
             <Carousel ref={PopularRef}>
               <Popular />
             </Carousel>
           </HomeSectionWrapper>
+          <HomeRecommendationWrapper>
+            <HomeRecommendationBackground>
+              <HomeSectionSubTitle>이건 탑승해야 돼</HomeSectionSubTitle>
+              <HomeSectionTitle>20대 개미들이 즐겨봐요</HomeSectionTitle>
+              <Carousel ref={RecommendationRef}>
+                <Recommendation />
+              </Carousel>
+            </HomeRecommendationBackground>
+          </HomeRecommendationWrapper>
           <HomeSectionWrapper>
-            <HomeSectionSubTitle>나만의 툰툰</HomeSectionSubTitle>
-            <HomeSectionTitle>비슷한 취향이 자주 보는 웹툰</HomeSectionTitle>
-            <Carousel ref={RecommendationRef}>
-              <Recommendation />
-            </Carousel>
-          </HomeSectionWrapper>
-          <HomeSectionWrapper>
-            <HomeSectionSubTitle>요일별 웹툰을 추천해요</HomeSectionSubTitle>
-            <HomeSectionTitle>오늘도 툰툰</HomeSectionTitle>
-            <Weekly />
+            <HomeSectionSubTitle>개미는 오늘도 줍줍</HomeSectionSubTitle>
+            <HomeSectionTitle>요일별 툰툰</HomeSectionTitle>
+            {/* <Weekly /> */}
           </HomeSectionWrapper>
         </HomeContainer>
       </DefaultLayout>

--- a/domains/webtoon/home/Popular.style.tsx
+++ b/domains/webtoon/home/Popular.style.tsx
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 const PopularWrapper = styled.div`
   display: flex;
   gap: 1.2rem;
-  margin: 0;
 `;
 
 const CarouselBox = styled.div`
   display: flex;
   flex-direction: column;
+  border-radius: 16px;
   background-color: ${(props) => props.theme.bg_color.primary};
   width: 120px;
   height: 120px;

--- a/domains/webtoon/home/RealTimeChart.style.tsx
+++ b/domains/webtoon/home/RealTimeChart.style.tsx
@@ -1,23 +1,30 @@
 import styled from '@emotion/styled';
 
+const RealTimeChartBoxContainer = styled.div`
+  display: flex;
+  gap: 2.4rem;
+`;
+
 const CarouselBox = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
   justify-content: flex-start;
-  margin: 0;
-  min-width: 300px;
+  width: 296px;
 `;
 
 const CarouselContent = styled.div`
   display: flex;
   flex-direction: row;
-  margin: 0;
+  gap: 1.2rem;
+
+  > :last-child {
+    margin-left: auto;
+  }
 `;
 
 // TODO: 이미지 태그로 변경할 것
 const CarouselContentCard = styled.div`
-  margin: 0;
   border-radius: 10px;
   background-color: ${(props) => props.theme.bg_color.primary};
   width: 52px;
@@ -52,7 +59,6 @@ const CarouselContentInformationWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin: 0;
 `;
 
 const CarouselContentTitle = styled.div`
@@ -60,7 +66,6 @@ const CarouselContentTitle = styled.div`
 `;
 
 const CarouselContentAuthor = styled.div`
-  margin: 0;
   color: ${(props) => props.theme.colors.grey_400};
   font-size: 1.4rem;
 `;
@@ -72,6 +77,7 @@ const CarouselContentScoreWrapper = styled.div`
 `;
 
 const CarouselContentScore = styled.div`
+  text-align: end;
   font-size: 1.6rem;
   font-weight: 600;
 `;
@@ -85,6 +91,7 @@ const CarouselContentScoreChangePercent = styled.div`
 `;
 
 export {
+  RealTimeChartBoxContainer,
   CarouselBox,
   CarouselContent,
   CarouselContentCard,

--- a/domains/webtoon/home/RealTimeChart.tsx
+++ b/domains/webtoon/home/RealTimeChart.tsx
@@ -1,4 +1,5 @@
 import {
+  RealTimeChartBoxContainer,
   CarouselContent,
   CarouselContentCard,
   CarouselContentRankingWrapper,
@@ -52,13 +53,13 @@ function RealTimeChartBox() {
 
 function RealTimeChart() {
   return (
-    <>
+    <RealTimeChartBoxContainer>
       <RealTimeChartBox />
       <RealTimeChartBox />
       <RealTimeChartBox />
       <RealTimeChartBox />
       <RealTimeChartBox />
-    </>
+    </RealTimeChartBoxContainer>
   );
 }
 

--- a/domains/webtoon/home/Recommendation.style.tsx
+++ b/domains/webtoon/home/Recommendation.style.tsx
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 const RecommendationWrapper = styled.div`
   display: flex;
   gap: 1.2rem;
-  margin: 0;
 `;
 
 const CarouselBox = styled.div`
   display: flex;
   flex-direction: column;
+  border-radius: 20px;
   background-color: ${(props) => props.theme.bg_color.primary};
   width: 200px;
   height: 200px;

--- a/domains/webtoon/home/Weekly.style.tsx
+++ b/domains/webtoon/home/Weekly.style.tsx
@@ -5,7 +5,6 @@ const WeeklyWrapper = styled.div`
   flex-wrap: wrap;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 1.2rem;
-  margin: 0;
   padding-bottom: 2rem;
   width: 100%;
 `;

--- a/styles/themes/themes.ts
+++ b/styles/themes/themes.ts
@@ -2,7 +2,7 @@
 // https://www.figma.com/file/fgeQYhg1cfGpb4sZe8cAi6/%EB%94%94%ED%94%84%EB%A7%8C-1%EB%B2%88-%EC%B6%9C%EA%B5%AC?node-id=3%3A17
 const themes = {
   bg_color: {
-    primary: '#F1F1F1',
+    primary: '#E9E9E9',
   },
   colors: {
     black: 'rgba(0, 0, 0, 1)',
@@ -13,6 +13,7 @@ const themes = {
     grey_200: '#f5f5f5',
     grey_300: '#cfcfcf',
     grey_400: '#A2A9B0',
+    grey_500: '#9E9E9E',
     point_up_100: '#FF4E16',
     point_up_0: 'rgba(255, 94, 26, 0.06)',
     point_down_100: 'rgba(28, 92, 255, 1)',


### PR DESCRIPTION
## 💡 개요

- 디자인 최신 버전인 UT 버전으로 싱크 해두었습니다. 
https://www.figma.com/file/fgeQYhg1cfGpb4sZe8cAi6/%EB%94%94%ED%94%84%EB%A7%8C-1%EB%B2%88-%EC%B6%9C%EA%B5%AC?node-id=478%3A1253

- 요일별 컴포넌트 및 홈 페이지에서 사용하는 컴포넌트 세부 조정은 다루지 않습니다.

## 📑 작업 사항

- 테마 수정
- css reset 의 마진 변경 대응
- 요일별 컴포넌트 홈 페이지에서 숨김
- 섹션 타이틀 피그마와 싱크