### PR TITLE
🐛 [사용자 프로필 이미지] default size 에서 props 값으로 변경

### DIFF
--- a/components/image/UserProfile.style.tsx
+++ b/components/image/UserProfile.style.tsx
@@ -1,10 +1,15 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 
-const ProfileImgWrap = styled.div`
+type ImgProps = {
+  width: string;
+  height: string;
+};
+
+const ProfileImgWrap = styled.div<ImgProps>`
   position: relative;
-  width: 3.2rem;
-  height: 3.2rem;
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
 `;
 
 const ProfileImg = styled(Image)`

--- a/components/image/UserProfile.tsx
+++ b/components/image/UserProfile.tsx
@@ -4,15 +4,17 @@ import { ProfileImgWrap, ProfileImg } from './UserProfile.style';
 
 type ImgProps = {
   src: string;
+  width: string;
+  height: string;
 };
 
-function UserProfile({ src }: ImgProps) {
+function UserProfile({ src, width, height }: ImgProps) {
   return (
-    <ProfileImgWrap>
+    <ProfileImgWrap width={width} height={height}>
       <ProfileImg
         src={src}
-        width="32"
-        height="32"
+        width={width}
+        height={height}
         layout="fixed"
         objectFit="cover"
       />

--- a/domains/webtoon/detail/Comment.tsx
+++ b/domains/webtoon/detail/Comment.tsx
@@ -28,7 +28,7 @@ function Comment() {
         {data.map((data) => {
           return (
             <CommentWrap key={data.id}>
-              <ProfileImg src={data.profileimg} />
+              <ProfileImg src={data.profileimg} width="32" height="32" />
               <MainWrap>
                 <UserInfo>
                   <Name>{data.name}</Name>


### PR DESCRIPTION
## 💡 개요

![image](https://user-images.githubusercontent.com/48766355/167168567-14130fd0-270d-4687-9193-481aae43fdd1.png)

- 피그마에서 사용자 이미지 컴포넌트 크기가 각 페이지마다 다르게 설정되는 것을 보고 `default` 사이즈에서 `props` 값으로 변경했습니다.

## 📑 작업 사항

- [x] 이미지 `css` 수정

## 🔎 기타

![image](https://user-images.githubusercontent.com/48766355/167168913-169eee5b-0ab9-4306-8fc9-c5642f2f6e96.png)

✨ 이미지 크기 선언하실 때 단위 작성 없이 `px` 기준으로 작성 부탁드립니다 👀

📝 관련 링크 : [[내보내번] Next.js docs - next/image](https://birdmee.tistory.com/10)