### PR TITLE
✨[웹툰 리스트]: 웹툰 리스트 api 연결 예제

### DIFF
--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,0 +1,5 @@
+import ky from 'ky';
+
+export const api = ky.create({
+  prefixUrl: process.env.NEXT_PUBLIC_API_ENDPOINT,
+});

--- a/apis/queryKeys.ts
+++ b/apis/queryKeys.ts
@@ -1,5 +1,7 @@
 const webtoons = {
   all: ['webtoons'],
+  lists: () => [...webtoons.all, 'list'],
+  list: (id: number) => [...webtoons.lists(), id],
 };
 
 export { webtoons };

--- a/apis/queryKeys.ts
+++ b/apis/queryKeys.ts
@@ -1,0 +1,5 @@
+const webtoons = {
+  all: ['webtoons'],
+};
+
+export { webtoons };

--- a/apis/webtoons.ts
+++ b/apis/webtoons.ts
@@ -1,0 +1,13 @@
+import { useQuery } from 'react-query';
+import { webtoons } from '@apis/queryKeys';
+import { api } from '.';
+
+const getWebtoons = async () => {
+  return await api.get('webtoons').json();
+};
+
+const useGetWebtoons = () => {
+  return useQuery(webtoons.all, getWebtoons);
+};
+
+export { getWebtoons, useGetWebtoons };

--- a/apis/webtoons.ts
+++ b/apis/webtoons.ts
@@ -6,8 +6,16 @@ const getWebtoons = async () => {
   return await api.get('webtoons').json();
 };
 
-const useGetWebtoons = () => {
-  return useQuery(webtoons.all, getWebtoons);
+const getWebtoonById = async (webtoonId: number) => {
+  return await api.get(`webtoons/${webtoonId}`).json();
 };
 
-export { getWebtoons, useGetWebtoons };
+const useGetWebtoons = () => {
+  return useQuery(webtoons.lists(), () => getWebtoons());
+};
+
+const useGetWebtoonById = (webtoonId: number) => {
+  return useQuery(webtoons.list(webtoonId), () => getWebtoonById(webtoonId));
+};
+
+export { getWebtoons, getWebtoonById, useGetWebtoons, useGetWebtoonById };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "emotion-reset": "^3.0.1",
     "emotion-theming": "^11.0.0",
     "json-loader": "^0.5.7",
+    "ky": "^0.30.0",
     "next": "12.1.4",
     "react": "18.0.0",
     "react-dom": "18.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
+import { useState } from 'react';
 import Head from 'next/head';
 
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from '@emotion/react';
@@ -9,10 +10,10 @@ import themes from '@styles/themes/themes';
 import GlobalStyle from '@styles/globalstyles/GlobalStyle';
 import Layout from '@components/layout/Layout';
 
-const queryClient = new QueryClient();
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function MyApp({ Component, pageProps }: any) {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
     <>
       <Head>
@@ -21,15 +22,17 @@ function MyApp({ Component, pageProps }: any) {
         <title>개미는 툰툰</title>
       </Head>
       <QueryClientProvider client={queryClient}>
-        <RecoilRoot>
-          <ThemeProvider theme={themes}>
-            <GlobalStyle />
-            <Layout>
-              <Component {...pageProps} />
-            </Layout>
-          </ThemeProvider>
-        </RecoilRoot>
-        <ReactQueryDevtools initialIsOpen={false} />
+        <Hydrate state={pageProps.dehydratedState}>
+          <RecoilRoot>
+            <ThemeProvider theme={themes}>
+              <GlobalStyle />
+              <Layout>
+                <Component {...pageProps} />
+              </Layout>
+            </ThemeProvider>
+          </RecoilRoot>
+          <ReactQueryDevtools initialIsOpen={false} />
+        </Hydrate>
       </QueryClientProvider>
     </>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,9 @@
 import type { NextPage } from 'next';
 import { default as _Home } from '@domains/webtoon/home/Home';
 import Header from '@components/layout/Header';
+import { QueryClient, dehydrate } from 'react-query';
+import { getWebtoons, useGetWebtoons } from '@apis/webtoons';
+import { webtoons } from '@apis/queryKeys';
 
 const Home: NextPage = () => {
   console.log(
@@ -10,6 +13,9 @@ const Home: NextPage = () => {
      /_/  |_|/_/  |/  /__/   \\____/ \\____/ /_/  |/ ',
   );
 
+  const { data, isSuccess, isLoading, isError } = useGetWebtoons();
+  console.log('webtoons', data, isSuccess, isLoading, isError);
+
   return (
     <>
       <Header leftBtn="logo" rightBtn="menu" />
@@ -17,5 +23,17 @@ const Home: NextPage = () => {
     </>
   );
 };
+
+export async function getServerSideProps() {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(webtoons.all, getWebtoons);
+
+  return {
+    props: {
+      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+    },
+  };
+}
 
 export default Home;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import type { NextPage } from 'next';
 import { default as _Home } from '@domains/webtoon/home/Home';
 import Header from '@components/layout/Header';
 import { QueryClient, dehydrate } from 'react-query';
-import { getWebtoons, useGetWebtoons } from '@apis/webtoons';
+import { getWebtoons, useGetWebtoonById, useGetWebtoons } from '@apis/webtoons';
 import { webtoons } from '@apis/queryKeys';
 
 const Home: NextPage = () => {
@@ -13,8 +13,15 @@ const Home: NextPage = () => {
      /_/  |_|/_/  |/  /__/   \\____/ \\____/ /_/  |/ ',
   );
 
-  const { data, isSuccess, isLoading, isError } = useGetWebtoons();
-  console.log('webtoons', data, isSuccess, isLoading, isError);
+  // SSR
+  const { data: webtoons, isSuccess, isLoading, isError } = useGetWebtoons();
+  console.log('webtoons', webtoons, isSuccess, isLoading, isError);
+
+  const webtoonId = 1;
+
+  // CSR
+  const { data: webtoon } = useGetWebtoonById(webtoonId);
+  console.log('webtoon', webtoon);
 
   return (
     <>
@@ -27,6 +34,7 @@ const Home: NextPage = () => {
 export async function getServerSideProps() {
   const queryClient = new QueryClient();
 
+  // SSR prefetch
   await queryClient.prefetchQuery(webtoons.all, getWebtoons);
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10850,6 +10850,11 @@ kuler@1.0.x:
   dependencies:
     colornames "^1.1.1"
 
+ky@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-0.30.0.tgz#a3d293e4f6c4604a9a4694eceb6ce30e73d27d64"
+  integrity sha512-X/u76z4JtDVq10u1JA5UQfatPxgPaVDMYTrgHyiTpGN2z4TMEJkIHsoSBBSg9SWZEIXTKsi9kHgiQ9o3Y/4yog==
+
 language-subtag-registry@~0.3.2:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz#04ac218bea46f04cb039084602c6da9e788dd45a"


### PR DESCRIPTION
## 💡 개요

api를 연결하는 예제임당

## 📑 작업 사항

- api client, react query, react query keys를 각각 따로 정의하고 합성해서 사용합니당
- `ky`는 `axios` 랑 똑같이 생겼는데 `fetch` 기반 임당
- `.env` 파일에 `NEXT_PUBLIC_API_ENDPOINT=https://api.antoon.fun/api/v1/` 등록해주세염 노션에도 갱신해두었음당

## 🔎 기타

질문이나, 공통으로 가져가고 싶은 구조 있으시면 코멘트 주세염!