### PR TITLE
✨ [상세 페이지] 댓글 리스트 조회 API 연결

### DIFF
--- a/apis/comments.ts
+++ b/apis/comments.ts
@@ -1,0 +1,16 @@
+import { useQuery } from 'react-query';
+import { comments } from './queryKeys';
+import { api } from './api';
+
+const getCommentsById = async (webtoonId: string | string[] | undefined) => {
+  return await api
+    .get(`webtoons/${webtoonId}/discussions`)
+    .then((res) => res.json())
+    .catch((e) => console.log(e));
+};
+
+const useGetCommentsById = (webtoonId: string | string[] | undefined) => {
+  return useQuery(comments.lists(webtoonId), () => getCommentsById(webtoonId));
+};
+
+export { getCommentsById, useGetCommentsById };

--- a/apis/queryKeys.ts
+++ b/apis/queryKeys.ts
@@ -8,4 +8,9 @@ const webtoons = {
   days: (day: string) => [...webtoons.all, 'days', day],
 };
 
-export { webtoons };
+const comments = {
+  all: ['comments'],
+  lists: (id: string | string[] | undefined) => [...comments.all, id],
+};
+
+export { webtoons, comments };

--- a/components/detail/commentTextInput/CommentTextInput.tsx
+++ b/components/detail/commentTextInput/CommentTextInput.tsx
@@ -22,7 +22,7 @@ function CommentTextInput(props: Props) {
   const [focused, setFocused] = useState(false);
   const [content, setContent] = useState('');
 
-  const placeHolderText = `${props.length}번째 행진에 동참해 보세요!`;
+  const placeHolderText = `${props.length + 1}번째 행진에 동참해 보세요!`;
 
   const ContentCheckHandler = useCallback(
     (text) => {

--- a/domains/webtoon/detail/Comment.style.tsx
+++ b/domains/webtoon/detail/Comment.style.tsx
@@ -1,5 +1,9 @@
 import styled from '@emotion/styled';
 
+const CommentListWrap = styled.div`
+  min-height: 30rem;
+`;
+
 const Title = styled.p`
   margin: 2.4rem 0;
   font-size: 2rem;
@@ -49,6 +53,7 @@ const Favorite = styled.span`
 `;
 
 export {
+  CommentListWrap,
   Title,
   CommentWrap,
   MainWrap,

--- a/domains/webtoon/detail/Comment.tsx
+++ b/domains/webtoon/detail/Comment.tsx
@@ -1,6 +1,7 @@
-import { comments } from './Comment.data';
+import { useGetCommentsById } from '@apis/comments';
 
 import {
+  CommentListWrap,
   Title,
   CommentWrap,
   MainWrap,
@@ -15,33 +16,41 @@ import {
 import UserProfile from '@components/image/UserProfile';
 import FavoriteBtn from '@components/button/FavoriteBtn';
 import CommentTextInput from '@components/detail/commentTextInput/CommentTextInput';
+import OnError from '@components/OnError';
+import ErrorBoundary from '@components/ErrorBoundary';
 
-function Comment() {
-  const data = comments;
+import { IComment } from '@_types/comments-type';
+
+function Comment({ id }: { id: string | string[] | undefined }) {
+  const { data: comments, isError } = useGetCommentsById(id);
+
+  if (isError) return <OnError>댓글을 불러오지 못하고 있어요 😭😭😭</OnError>;
 
   return (
-    <>
-      <Title>개미들의 행진 {data.length}</Title>
-      <CommentTextInput length={data.length} />
-      {data.map((data) => {
-        return (
-          <CommentWrap key={data.id}>
-            <UserProfile src={data.profileimg} width="32" height="32" />
-            <MainWrap>
-              <UserInfo>
-                <Name>{data.name}</Name>
-                <TimeStamp>{data.timestamp}분전</TimeStamp>
-              </UserInfo>
-              <Content>{data.content}</Content>
-              <FavoriteWrap>
-                <FavoriteBtn isFavoriteChecked={data.isFavoriteChecked} />
-                <Favorite>{data.favorite}</Favorite>
-              </FavoriteWrap>
-            </MainWrap>
-          </CommentWrap>
-        );
-      })}
-    </>
+    <ErrorBoundary message="댓글을 불러오지 못하고 있어요 😭😭😭">
+      <CommentListWrap>
+        <Title>개미들의 행진 {comments?.data.length}</Title>
+        <CommentTextInput length={comments?.data.length} />
+        {comments?.data.map((comment: IComment) => {
+          return (
+            <CommentWrap key={comment.discussionId}>
+              <UserProfile src={comment.imageUrl} width="32" height="32" />
+              <MainWrap>
+                <UserInfo>
+                  <Name>{comment.nickname}</Name>
+                  <TimeStamp>몇 분 전일까요?</TimeStamp>
+                </UserInfo>
+                <Content>{comment.content}</Content>
+                <FavoriteWrap>
+                  <FavoriteBtn isFavoriteChecked={comment.isUserLike} />
+                  <Favorite>{comment.likeCount}</Favorite>
+                </FavoriteWrap>
+              </MainWrap>
+            </CommentWrap>
+          );
+        })}
+      </CommentListWrap>
+    </ErrorBoundary>
   );
 }
 

--- a/pages/webtoon/[id].tsx
+++ b/pages/webtoon/[id].tsx
@@ -1,12 +1,14 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import Detail from '@domains/webtoon/detail/Detail';
-import { Webtoon } from '@_types/webtoon-type';
+import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { ChartData } from '@_types/chart-type';
-import React, { useEffect } from 'react';
-import Header from '@components/layout/Header/Header';
-import Comment from '@domains/webtoon/detail/Comment';
 import { Mixpanel } from 'mixpanel';
+
+import { Webtoon } from '@_types/webtoon-type';
+import { ChartData } from '@_types/chart-type';
+
+import Header from '@components/layout/Header/Header';
+import Detail from '@domains/webtoon/detail/Detail';
+import Comment from '@domains/webtoon/detail/Comment';
 
 const webtoonMock: Webtoon = {
   id: 1,
@@ -21,6 +23,7 @@ const webtoonMock: Webtoon = {
   thumnail:
     'https://blog.kakaocdn.net/dn/bSAMGD/btqGbrklfgR/vuBgYTfwQP0Cq2ZW0G3ZXK/img.png',
 };
+
 const ChartMock: ChartData = {
   label: 'daily',
   timeseries: {
@@ -43,17 +46,16 @@ function webtoonDetail() {
       page: '웹툰 상세 페이지',
       webtoonId: id,
     });
-  }, []);
-
-  console.log(`[router-checking]: ...${id}...`);
+  }, [id]);
 
   // Mock
   const mock = webtoonMock;
+
   return (
     <>
       <Header />
       <Detail key={mock.id} item={mock} chartData={ChartMock} />
-      <Comment />
+      <Comment id={id} />
     </>
   );
 }

--- a/types/comments-type.ts
+++ b/types/comments-type.ts
@@ -1,0 +1,10 @@
+export interface IComment {
+  webtoonId: number;
+  discussionId: number;
+  content: string;
+  userId: number;
+  nickname: string;
+  imageUrl: string;
+  likeCount: number;
+  isUserLike: boolean;
+}


### PR DESCRIPTION
## 💡 개요

- 상세 페이지 댓글 리스트 조회 API 연결했습니다.

## 📑 작업 사항

- [x] 댓글 리스트 조회 API 연결
- [x] 댓글 리스트 type 선언
- [x] 임시로 댓글 컴포넌트 `min-height` 설정

## 🔎 기타

💬 추가 논의 사항

댓글이 없을 때는 아래 사진처럼 댓글 입력 창 전체가 버튼으로 가려져서

![image](https://user-images.githubusercontent.com/48766355/170757309-570c5a6a-758e-4839-a9dd-b705b2a06a9c.png)

일단 임시로 댓글 컴포넌트 자체에 `min-height` 설정하긴 했는데

![image](https://user-images.githubusercontent.com/48766355/170757335-8e6f6843-0697-47ee-a16e-d501ffdb2b33.png)

댓글이 여러 개 있어도 마지막 댓글은 버튼으로 가려져서 조금 어색한 상태라고 생각합니다 🤔

![image](https://user-images.githubusercontent.com/48766355/170757363-b8e5745b-b279-4827-a479-7838f88e1899.png)

지금 피그마 스크린 디자인에도 마지막 댓글은 버튼으로 가려지는데 조금 어색하다고 생각합니다...!

![image](https://user-images.githubusercontent.com/48766355/170756704-22e2d836-e9bb-48ef-8777-373e75dcbac5.png)

병현님과 푸름님은 어떻게 생각하시는지 궁금해서 여쭤봅니다 🥺👀

그리고 디자이너 분들과

1. 댓글이 없는 상태에서 버튼 위치
2. 지금처럼 마지막 댓글은 가려지는 형태로 확정인지

등등 같이 얘기해보면 좋을 거 같습니다!! 🙌
