### PR TITLE
✨ [홈 페이지] 프리패치에서 클라이언트로 패치로 변경

### DIFF
--- a/apis/webtoons.ts
+++ b/apis/webtoons.ts
@@ -40,7 +40,10 @@ const getWebtoonsRanks = async () => {
   return await api
     .get('top-ranks')
     .then((res) => res.data)
-    .catch((e) => console.log(e));
+    .catch((e) => {
+      console.log(e);
+      return e;
+    });
 };
 
 const useGetWebtoonsRanks = () => {
@@ -65,7 +68,10 @@ const getWebtoonsGenres = async () => {
   return await api
     .get('webtoons/genres')
     .then((res) => res.data)
-    .catch((e) => console.log(e));
+    .catch((e) => {
+      console.log(e);
+      return e;
+    });
 };
 
 const useGetWebtoonsGenres = () => {
@@ -76,7 +82,10 @@ const getWebtoonsRecommendation = async () => {
   return await api
     .get('webtoons/ages')
     .then((res) => res.data)
-    .catch((e) => console.log(e));
+    .catch((e) => {
+      console.log(e);
+      return e;
+    });
 };
 
 const useGetWebtoonsRecommendation = () => {

--- a/components/spinner/LoadingSpinner.tsx
+++ b/components/spinner/LoadingSpinner.tsx
@@ -1,0 +1,11 @@
+import MoonLoader from 'react-spinners/MoonLoader';
+
+function LoadingSpinner() {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
+      <MoonLoader size={20} />
+    </div>
+  );
+}
+
+export default LoadingSpinner;

--- a/domains/webtoon/home/Genres.tsx
+++ b/domains/webtoon/home/Genres.tsx
@@ -2,6 +2,7 @@ import { webtoons } from '@apis/queryKeys';
 import { getWebtoonsGenresTop3 } from '@apis/webtoons';
 import ErrorBoundary from '@components/ErrorBoundary';
 import OnError from '@components/OnError';
+import LoadingSpinner from '@components/spinner/LoadingSpinner';
 import { Genre, WebtoonGenresTop3 } from '@_types/webtoon-type';
 import { useQuery } from 'react-query';
 import {
@@ -87,12 +88,14 @@ const genres: GenreData[] = [
 ];
 
 function Genres() {
-  const { data } = useQuery<WebtoonGenresTop3>(
+  const { data, isLoading, isError } = useQuery<WebtoonGenresTop3>(
     webtoons.genresTop3(),
     getWebtoonsGenresTop3,
   );
 
-  if (data === undefined)
+  if (isLoading) return <LoadingSpinner />;
+
+  if (data === undefined || isError)
     return <OnError>장르별 웹툰을 불러오지 못하고 있어요 😭😭😭</OnError>;
 
   const genreMap = new Map<string, string[]>();

--- a/domains/webtoon/home/RealTimeChart.tsx
+++ b/domains/webtoon/home/RealTimeChart.tsx
@@ -18,9 +18,10 @@ import { default as RealTimeChartScoreChangeIcon } from '@assets/icons/ScoreChan
 import { useGetWebtoonsRanks } from '@apis/webtoons';
 import OnError from '@components/OnError';
 import ErrorBoundary from '@components/ErrorBoundary';
+import LoadingSpinner from '@components/spinner/LoadingSpinner';
 
 function RealTimeChart() {
-  const { data } = useGetWebtoonsRanks();
+  const { data, isLoading, isError } = useGetWebtoonsRanks();
 
   const [isSSR, setIsSSR] = useState(true);
 
@@ -28,7 +29,9 @@ function RealTimeChart() {
     setIsSSR(false);
   }, []);
 
-  if (data === undefined)
+  if (isLoading) return <LoadingSpinner />;
+
+  if (data === undefined || isError)
     return <OnError>랭킹을 불러오지 못하고 있어요 😭😭😭</OnError>;
 
   return (

--- a/domains/webtoon/home/Recommendation.tsx
+++ b/domains/webtoon/home/Recommendation.tsx
@@ -1,10 +1,10 @@
+import { useQuery } from 'react-query';
+import MoonLoader from 'react-spinners/MoonLoader';
 import { webtoons } from '@apis/queryKeys';
 import { getWebtoonsRecommendation } from '@apis/webtoons';
+import { WebtoonRecommendation } from '@_types/webtoon-type';
 import ErrorBoundary from '@components/ErrorBoundary';
 import OnError from '@components/OnError';
-import { WebtoonRecommendation } from '@_types/webtoon-type';
-import React from 'react';
-import { useQuery } from 'react-query';
 import {
   RecommendationWrapper,
   CarouselBox,
@@ -14,12 +14,15 @@ import {
   RideHeadCount,
   Thumbnail,
 } from './Recommendation.style';
+import LoadingSpinner from '@components/spinner/LoadingSpinner';
 
 function Recommendation() {
-  const { data, isError } = useQuery<WebtoonRecommendation>(
+  const { data, isLoading, isError } = useQuery<WebtoonRecommendation>(
     webtoons.recommendation(),
     getWebtoonsRecommendation,
   );
+
+  if (isLoading) return <LoadingSpinner />;
 
   if (data === undefined || isError)
     return <OnError>연령별 웹툰을 불러오지 못하고 있어요 😭😭😭</OnError>;

--- a/domains/webtoon/home/Rising.tsx
+++ b/domains/webtoon/home/Rising.tsx
@@ -11,44 +11,54 @@ import {
   RisingTitle,
 } from './Rising.style';
 import { WebtoonRising } from '@_types/webtoon-type';
+import LoadingSpinner from '@components/spinner/LoadingSpinner';
+import OnError from '@components/OnError';
+import ErrorBoundary from '@components/ErrorBoundary';
 
 function Rising() {
-  const { data } = useQuery<WebtoonRising>(
+  const { data, isLoading, isError } = useQuery<WebtoonRising>(
     webtoons.rising(),
     getWebtoonsRising,
   );
 
+  if (isLoading) return <LoadingSpinner />;
+
+  if (data === undefined || isError)
+    return <OnError>상승중인 웹툰을 불러오지 못하고 있어요 😭😭😭</OnError>;
+
   return (
-    <RisingWrapper>
-      {data?.webtoons.map((webtoon) => (
-        <RisingCardWrapper key={webtoon.id} href={`webtoon/${webtoon.id}`}>
-          <RisingCard
-            alt={webtoon.title}
-            src={webtoon.thumbnail}
-            width={120}
-            height={120}
-            layout="fixed"
-          />
-          <RisingInformationWrapper>
-            <RisingTitle>{webtoon.title}</RisingTitle>
-          </RisingInformationWrapper>
-          <RisingScoreWrapper>
-            <RisingScoreChangePercent
-              scoreChangedStatus={
-                webtoon.scoreGapPercent > 0
-                  ? 'up'
-                  : webtoon.scoreGapPercent < 0
-                  ? 'down'
-                  : 'stable'
-              }
-            >
-              {webtoon.scoreGapPercent > 0 ? '+' : ''}
-              {webtoon.scoreGapPercent.toFixed(2)}%
-            </RisingScoreChangePercent>
-          </RisingScoreWrapper>
-        </RisingCardWrapper>
-      ))}
-    </RisingWrapper>
+    <ErrorBoundary message="상승중인 웹툰을 불러오지 못하고 있어요 😭😭😭">
+      <RisingWrapper>
+        {data?.webtoons.map((webtoon) => (
+          <RisingCardWrapper key={webtoon.id} href={`webtoon/${webtoon.id}`}>
+            <RisingCard
+              alt={webtoon.title}
+              src={webtoon.thumbnail}
+              width={120}
+              height={120}
+              layout="fixed"
+            />
+            <RisingInformationWrapper>
+              <RisingTitle>{webtoon.title}</RisingTitle>
+            </RisingInformationWrapper>
+            <RisingScoreWrapper>
+              <RisingScoreChangePercent
+                scoreChangedStatus={
+                  webtoon.scoreGapPercent > 0
+                    ? 'up'
+                    : webtoon.scoreGapPercent < 0
+                    ? 'down'
+                    : 'stable'
+                }
+              >
+                {webtoon.scoreGapPercent > 0 ? '+' : ''}
+                {webtoon.scoreGapPercent.toFixed(2)}%
+              </RisingScoreChangePercent>
+            </RisingScoreWrapper>
+          </RisingCardWrapper>
+        ))}
+      </RisingWrapper>
+    </ErrorBoundary>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-loading-skeleton": "^3.1.0",
     "react-query": "^3.34.19",
     "react-slick": "^0.29.0",
+    "react-spinners": "^0.12.0",
     "recoil": "^0.7.0",
     "slick-carousel": "^1.8.1",
     "url-loader": "^4.1.1"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage } from 'next';
 import { useEffect } from 'react';
-import { QueryClient, dehydrate } from 'react-query';
 import { getCookie } from 'cookies-next';
 import { Mixpanel } from 'mixpanel';
 
@@ -10,13 +9,7 @@ import { default as _Home } from '@domains/webtoon/home/Home';
 import FloatingBtn from '@components/button/FloatingBtn';
 
 import { api } from '@apis/api';
-import { webtoons } from '@apis/queryKeys';
-import {
-  getWebtoonsRanks,
-  getWebtoonsRecommendation,
-  getWebtoonsGenresTop3,
-  getWebtoonsRising,
-} from '@apis/webtoons';
+
 import { useGetUserInformation } from '@apis/user';
 
 const Home: NextPage = () => {
@@ -34,7 +27,7 @@ const Home: NextPage = () => {
   return (
     <>
       {isSuccess ? (
-        <Header leftBtn="logo" rightBtn="menu" imageUrl={user.imageUrl} />
+        <Header leftBtn="logo" rightBtn="menu" imageUrl={user?.imageUrl} />
       ) : (
         <Header leftBtn="logo" rightBtn="menu" />
       )}
@@ -44,23 +37,5 @@ const Home: NextPage = () => {
     </>
   );
 };
-
-export async function getServerSideProps() {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery(webtoons.ranks(), getWebtoonsRanks);
-  await queryClient.prefetchQuery(webtoons.rising(), getWebtoonsRising);
-  await queryClient.prefetchQuery(
-    webtoons.recommendation(),
-    getWebtoonsRecommendation,
-  );
-  await queryClient.prefetchQuery(webtoons.genresTop3(), getWebtoonsGenresTop3);
-
-  return {
-    props: {
-      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
-    },
-  };
-}
 
 export default Home;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2637,7 +2637,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
-"@emotion/react@^11.8.2":
+"@emotion/react@^11.4.1", "@emotion/react@^11.8.2":
   version "11.9.0"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.9.0.tgz#b6d42b1db3bd7511e7a7c4151dc8bc82e14593b8"
   integrity sha512-lBVSF5d0ceKtfKCDQJveNAtkC7ayxpVlgOohLgXqRwqWr9bOf4TZAFFyIcNngnV6xK6X4x2ZeXq7vliHkoVkxQ==
@@ -14661,6 +14661,13 @@ react-slick@^0.29.0:
     json2mq "^0.2.0"
     lodash.debounce "^4.0.8"
     resize-observer-polyfill "^1.5.0"
+
+react-spinners@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.12.0.tgz#082b3e247878c7dc4f89ba7f23d6994aa2269075"
+  integrity sha512-kC/3g4Dk3kBaVfYVu7f+Zxd9wTxt6Lzws5cP3jCuE03TZwTNtwS++ZGUNF8BR3M8UrUFXP0gil0L9LONOsUkjw==
+  dependencies:
+    "@emotion/react" "^11.4.1"
 
 react-syntax-highlighter@^13.5.3:
   version "13.5.3"


### PR DESCRIPTION
## 💡 개요

홈에서 일단 마크업을 보여주고 로딩하는게 사용자 경험이 좋아보여서 변경

## 📑 작업 사항

- [x] 홈에서 사용하는 api 들 프리패치에서 클라이언트로 변경
- [x] 로딩 스피너 추가했습니다.

## 🔎 기타

타임아웃 에러는 잡지 못하고 있더라구여...