### PR TITLE
🐛 [홈] 요일별 웹툰의 요일 선택을 올바르게 표시함

### DIFF
--- a/domains/webtoon/home/Weekly.style.tsx
+++ b/domains/webtoon/home/Weekly.style.tsx
@@ -17,7 +17,9 @@ type DaySelectButtonProps = {
 };
 
 const DaySelectButton = styled.button<DaySelectButtonProps>`
-  transition: all 300ms ease-in-out;
+  transition-duration: 200ms;
+  transition-property: background-color, color;
+  transition-timing-function: ease;
   border-radius: 24px;
   background-color: ${(props) =>
     props.selected ? props.theme.colors.grayscale.gray_800 : 'unset'};

--- a/domains/webtoon/home/Weekly.tsx
+++ b/domains/webtoon/home/Weekly.tsx
@@ -7,7 +7,8 @@ import {
 import WeeklyWebtoons from './WeeklyWebtoons';
 import { Day } from '@_types/webtoon-type';
 
-const days = ['월', '화', '수', '목', '금', '토', '일'];
+const displayDays = ['월', '화', '수', '목', '금', '토', '일'];
+const days = ['일', '월', '화', '수', '목', '금', '토'];
 const today = days[new Date().getDay()] as Day;
 
 function Weekly() {
@@ -20,7 +21,7 @@ function Weekly() {
   return (
     <WeeklyContainer>
       <DaySelectButtonWContainer>
-        {days.map((day) => (
+        {displayDays.map((day) => (
           <DaySelectButton
             key={day}
             selected={day === selectedDay}


### PR DESCRIPTION
## 💡 개요

이전에 요일별 순서를 디자인 바뀌면서 바꿨는데 로직을 바꾸지 않아 버그가 생겼었습니다.

https://app.asana.com/0/1202299457003825/1202417420969678/f

## 📑 작업 사항

- [x] 요일별 표시를 올바르게 표시함
<img width="615" alt="스크린샷 2022-06-10 오후 10 21 02" src="https://user-images.githubusercontent.com/50096419/173073633-b39a6fe1-c9e7-4ef0-9461-e9a1c1db67c2.png">


## 🔎 기타

어쩔때 마다 요일선택이 기존에 선택한 요일이 남게되는데 이건 api 연결이 안되어있으면 확인이 안되는 버그일지도 모르겠습니다.. 로컬에서는 문제없어 보이네여.. 🤔 