### PR TITLE
♻️ refac: API default header 설정 방식 변경

### DIFF
--- a/apis/api.ts
+++ b/apis/api.ts
@@ -1,11 +1,16 @@
 import axios from 'axios';
 import { getCookie } from 'cookies-next';
 
-export const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
-});
+export const instance = () => {
+  const api = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
+  });
 
-export const auth_api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
-  headers: { Authorization: `Bearer ${getCookie('Access')}` },
-});
+  const accessToken = getCookie('Access');
+
+  api.defaults.headers.common['Authorization'] = accessToken
+    ? `Bearer ${accessToken}`
+    : '';
+
+  return api;
+};

--- a/apis/comments.ts
+++ b/apis/comments.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { comments } from './queryKeys';
-import { api, auth_api } from './api';
+import { instance } from './api';
 
 const getCommentsById = async (id: number) => {
-  return await api
+  return await instance()
     .get(`webtoons/${id}/discussions`)
     .then((res) => res.data)
     .catch((e) => console.log(e));
@@ -14,7 +14,7 @@ const useGetCommentsById = (id: number) => {
 };
 
 const getCommentsLikedById = async (id: number) => {
-  return await api
+  return await instance()
     .put(`webtoons/discussions/${id}/likes`)
     .then((res) => res.data)
     .catch((e) => console.log(e));
@@ -27,7 +27,7 @@ const usePutCommentsLikedById = (id: number) => {
 };
 
 const postCommentsById = async (id: number, content: string) => {
-  return await auth_api
+  return await instance()
     .post(`webtoons/${id}/discussions`, { content: content })
     .then((res) => res.data)
     .catch((e) => console.log(e));

--- a/apis/queryKeys.ts
+++ b/apis/queryKeys.ts
@@ -27,9 +27,12 @@ const comments = {
 };
 
 const user = {
-  all: ['userInfo'],
+  all: ['user'],
   tokens: (refreshToken: string) => [...user.all, 'tokens', refreshToken],
+  delete: (refreshToken: string) => [...user.all, 'delete', refreshToken],
   information: () => [...user.all, 'information'],
+  updateName: (userName: string) => [...user.all, 'update', userName],
+  updateImg: (userImg: string) => [...user.all, 'update', userImg],
 };
 
 const graph = {

--- a/apis/webtoons.ts
+++ b/apis/webtoons.ts
@@ -1,6 +1,6 @@
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQuery } from 'react-query';
 import { graph, webtoons } from '@apis/queryKeys';
-import { api, auth_api } from './api';
+import { instance } from './api';
 import {
   WebtoonRank,
   WebtoonGenres,
@@ -14,7 +14,7 @@ import {
 import { Graph } from '@_types/chart-type';
 
 const getWebtoons = async () => {
-  return await api
+  return await instance()
     .get('webtoons')
     .then((res) => res.data)
     .catch((e) => console.log(e));
@@ -25,7 +25,7 @@ const useGetWebtoons = () => {
 };
 
 const getWebtoonById = async (webtoonId: number) => {
-  return await api
+  return await instance()
     .get(`webtoons/${webtoonId}`)
     .then((res) => res.data)
     .catch((e) => console.log(e));
@@ -38,7 +38,7 @@ const useGetWebtoonById = (webtoonId: number) => {
 };
 
 const getWebtoonsRanks = async () => {
-  return await api
+  return await instance()
     .get('top-ranks')
     .then((res) => res.data)
     .catch((e) => {
@@ -52,7 +52,7 @@ const useGetWebtoonsRanks = () => {
 };
 
 const getWebtoonsRising = async () => {
-  return await api
+  return await instance()
     .get('webtoons/top-upper')
     .then((res) => res.data)
     .catch((e) => {
@@ -66,7 +66,7 @@ const useGetWebtoonsRising = () => {
 };
 
 const getWebtoonsGenres = async () => {
-  return await api
+  return await instance()
     .get('webtoons/genres')
     .then((res) => res.data)
     .catch((e) => {
@@ -80,7 +80,7 @@ const useGetWebtoonsGenres = () => {
 };
 
 const getWebtoonsRecommendation = async () => {
-  return await api
+  return await instance()
     .get('webtoons/ages')
     .then((res) => res.data)
     .catch((e) => {
@@ -96,7 +96,7 @@ const useGetWebtoonsRecommendation = () => {
 };
 
 const getWebtoonsGenresTop3 = async () => {
-  return await api
+  return await instance()
     .get('webtoons/genres/top3')
     .then((res) => res.data)
     .catch((e) => {
@@ -112,7 +112,7 @@ const useGetWebtoonsGenresTop3 = () => {
 };
 
 const getWebtoonsByDay = async (day: string) => {
-  return await api
+  return await instance()
     .get(`webtoons/days/${day}`)
     .then((res) => res.data)
     .catch((e) => {
@@ -128,7 +128,7 @@ const useGetWebtoonsByDay = (day: string) => {
 };
 
 const getGraphScore = async (webtoonId: number, chartType: string) => {
-  return await api
+  return await instance()
     .get(`webtoons/${webtoonId}/graph-scores/${chartType}`)
     .then((res) => res.data)
     .catch((e) => console.log(e));
@@ -144,7 +144,7 @@ const getJoinLeaveRecommendationById = async (
   webtoonId: number,
   status: string,
 ) => {
-  return await auth_api
+  return await instance()
     .patch(`recommendations/${webtoonId}?status=${status}`)
     .then((res) => res.data)
     .catch((e) => console.log(e));

--- a/domains/search/AutoCompletList.tsx
+++ b/domains/search/AutoCompletList.tsx
@@ -1,7 +1,7 @@
 import SearchIcon from '@assets/icons/SearchIcon';
 import { useRouter } from 'next/router';
 
-import { api } from '@apis/api';
+import { instance } from '@apis/api';
 
 import { AutoCompleteListWrap, AutoCompleteList } from './AutoComplet.style';
 
@@ -18,7 +18,7 @@ function AutoCompletList({
 
   const onClickAutoCompleteList = async () => {
     try {
-      const keywordResults = await api.post(`webtoons/search`, {
+      const keywordResults = await instance().post(`webtoons/search`, {
         webtoons: [autoCompleteList.id],
       });
 

--- a/domains/search/Search.tsx
+++ b/domains/search/Search.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useRouter } from 'next/router';
 
-import { api } from '@apis/api';
+import { instance } from '@apis/api';
 
 import autoComplete from 'utils/autoComplete';
 
@@ -29,7 +29,7 @@ function Search({ webtoons }: { webtoons: [] }) {
     [setSearchInput],
   );
 
-  const resetInput = useCallback(() => {
+  const onResetInput = useCallback(() => {
     setSearchInput('');
   }, []);
 
@@ -49,7 +49,7 @@ function Search({ webtoons }: { webtoons: [] }) {
   const onKeyDownEnter = async (e: any) => {
     if (e.key == 'Enter' && searchLists.length > 0) {
       try {
-        const keywordResults = await api.post(`webtoons/search`, {
+        const keywordResults = await instance().post(`webtoons/search`, {
           webtoons: searchLists,
         });
 
@@ -71,7 +71,7 @@ function Search({ webtoons }: { webtoons: [] }) {
         searchInput={searchInput}
         onChangeInput={onChangeInput}
         onKeyDownEnter={onKeyDownEnter}
-        resetInput={resetInput}
+        onResetInput={onResetInput}
         setSearchResults={setSearchResults}
       />
       {searchInput == '' ? (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,11 @@
 import type { NextPage } from 'next';
 import { useEffect } from 'react';
-import { getCookie } from 'cookies-next';
 import { Mixpanel } from 'mixpanel';
 
 import Header from '@components/layout/Header/Header';
 import Modal from '@components/modal/onboard/Modal';
 import { default as _Home } from '@domains/webtoon/home/Home';
 import FloatingBtn from '@components/button/FloatingBtn';
-
-import { api } from '@apis/api';
 
 import { useGetUserInformation } from '@apis/user';
 
@@ -19,15 +16,12 @@ const Home: NextPage = () => {
     });
   }, []);
 
-  const accessToken = getCookie('Access');
-  api.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-
-  const { data: user, isSuccess } = useGetUserInformation();
+  const { data: user } = useGetUserInformation();
 
   return (
     <>
-      {isSuccess ? (
-        <Header leftBtn="logo" rightBtn="menu" imageUrl={user?.imageUrl} />
+      {user ? (
+        <Header leftBtn="logo" rightBtn="menu" imageUrl={user.imageUrl} />
       ) : (
         <Header leftBtn="logo" rightBtn="menu" />
       )}

--- a/pages/user/signin.tsx
+++ b/pages/user/signin.tsx
@@ -5,8 +5,6 @@ import { useEffect } from 'react';
 import { setCookies } from 'cookies-next';
 import { Mixpanel } from 'mixpanel';
 
-import { api } from '@apis/api';
-
 import KakaoLoginImg from '@assets/images/KakaoLoginImg';
 import ChebronRightIcon from '@assets/icons/ChebronRightIcon';
 
@@ -62,11 +60,17 @@ export async function getServerSideProps({
   const accessToken = authArr && authArr[2];
   const refreshToken = authArr && authArr[4];
 
-  api.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-  setCookies('Access', accessToken, { req, res, maxAge: 60 * 60 * 24 * 60 });
-  setCookies('Refresh', refreshToken, { req, res, maxAge: 60 * 60 * 24 * 60 });
+  accessToken &&
+    setCookies('Access', accessToken, { req, res, maxAge: 60 * 60 * 24 * 60 });
 
-  if (status === 'signup') {
+  refreshToken &&
+    setCookies('Refresh', refreshToken, {
+      req,
+      res,
+      maxAge: 60 * 60 * 24 * 60,
+    });
+
+  if (status === 'SIGNUP') {
     return {
       redirect: {
         destination: '/user/signup/policy',
@@ -75,7 +79,7 @@ export async function getServerSideProps({
     };
   }
 
-  if (status === 'success') {
+  if (status === 'SUCCESS') {
     return {
       redirect: {
         destination: '/',


### PR DESCRIPTION
## 💡 개요

각 페이지에서 매번 Access Token을 Default Header로 설정하는 방식에서 

```ts
export const instance = () => {
  const api = axios.create({
    baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
  });

  const accessToken = getCookie('Access');

  api.defaults.headers.common['Authorization'] = accessToken
    ? `Bearer ${accessToken}`
    : '';

  return api;
};
```

한 번만 설정하는 방식으로 변경하고 모든 API에 적용했습니다.
실제로 잘 동작하는지 페이지마다 테스트 완료했습니다 🥺

## 📑 작업 사항

- [x] API default header 설정 방식 변경

## 🔎 기타

전에 사용했던 api 상수 대신 instance 함수를 사용해 주시면 됩니다!
근데 위와 같은 방법이 최선인지에 대해 고민이 많습니다 .. 괜찮을까요 ..? 🤔👀