### PR TITLE
:fire:[fix]: 상세 캐러셀 margin, 폰트 사이즈, null값 에러 버그 Fix

### DIFF
--- a/components/detail/category/Category.style.tsx
+++ b/components/detail/category/Category.style.tsx
@@ -4,16 +4,20 @@ import 'slick-carousel/slick/slick-theme.css';
 
 const SliderWrapper = styled.div`
   & .slick-slide {
-    margin: 0 3px;
+    padding: 0 4px;
   }
 
   & .slick-list {
+    margin: 0 0.1rem;
+
     & .slick-track {
-      width: 500% !important;
+      width: 300% !important;
     }
   }
 `;
-const CategoryCardWrapper = styled.div``;
+const CategoryCardWrapper = styled.div`
+  width: 100%;
+`;
 
 const CategorySliderCard = styled.div`
   position: relative;
@@ -29,7 +33,6 @@ const CategoryTitle = styled.p`
   margin-top: 12px;
   margin-left: 14px;
   color: ${(props) => props.theme.colors.grayscale.gray_800};
-  font-family: Pretendard;
   font-size: 12px;
 `;
 

--- a/domains/webtoon/detail/Detail.tsx
+++ b/domains/webtoon/detail/Detail.tsx
@@ -149,6 +149,7 @@ function Detail({ id }: { id: number }) {
         .reduce((acc, cur) => `${acc},${cur.day}`, '')
         .substring(1),
     };
+    if (normalPublishedday.day == 'null') return '없음';
 
     switch (data.publishDays.length) {
       case 0:


### PR DESCRIPTION
## 💡 개요
  - 상세 버그 수정
  - 캐러셀 카드 타이틀 텍스트는 모바일 환경 테스트 필요
  - 캐러셀 카드쪽 API 문자열 null값 에러 뱉는 것에 대한 핸들링 처리 추가

## 🥰기타
  - 머지 히스토리 삭제 🥰 