### PR TITLE
🚑️ [로그아웃] 토큰 도메인 수정

### DIFF
--- a/domains/user/mypage/MyPage.tsx
+++ b/domains/user/mypage/MyPage.tsx
@@ -36,8 +36,8 @@ function MyPage() {
 
   const onClickLogOut = () => {
     mutateLogOut();
-    removeCookies('Access', { path: '/', domain: 'antoon.fun' });
-    removeCookies('Refresh', { path: '/', domain: 'antoon.fun' });
+    removeCookies('Access', { path: '/', domain: 'https://antoon.fun' });
+    removeCookies('Refresh', { path: '/', domain: 'https://antoon.fun' });
     router.push('/');
   };
 


### PR DESCRIPTION
## 💡 개요

- access 토큰 쿠키 제거할 때 도메인 설정을 `antoon.fun`에서 `https://antoon.fun`으로 수정했습니다.

## 📑 작업 사항

- [x] 토큰 도메인 수정

## 🔎 기타