### PR TITLE
🩹 [마이페이지] 사용자 이름 수정하기 버그 픽스

### DIFF
--- a/domains/user/mypage/UserData.style.tsx
+++ b/domains/user/mypage/UserData.style.tsx
@@ -31,4 +31,16 @@ const UserProfileDataWrap = styled.div`
   align-items: center;
 `;
 
-export { UserDataWrap, UserName, UserDefaultName, UserProfileDataWrap };
+const EditNameWrap = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+`;
+
+export {
+  UserDataWrap,
+  UserName,
+  UserDefaultName,
+  UserProfileDataWrap,
+  EditNameWrap,
+};

--- a/domains/user/mypage/UserData.tsx
+++ b/domains/user/mypage/UserData.tsx
@@ -10,27 +10,27 @@ import {
   UserProfileDataWrap,
   UserName,
   UserDefaultName,
+  EditNameWrap,
 } from './UserData.style';
 
 import { IProfile } from '@_types/user-type';
 
 function UserData({ profile }: IProfile) {
   const router = useRouter();
-
   return (
     <UserDataWrap>
       <UserProfileDataWrap>
         {profile ? (
           <>
             <UserProfile src={profile.imageUrl} width="56" height="56" />
-            <UserName>{profile.name}</UserName>
-            <button
+            <EditNameWrap
               onClick={() => {
                 router.push('/user/mypage/edit');
               }}
             >
+              <UserName>{profile.name}</UserName>
               <ChebronRightIcon />
-            </button>
+            </EditNameWrap>
           </>
         ) : (
           <>


### PR DESCRIPTION
## 💡 개요

- [QA [개선/기능] 마이페이지에서 닉네임 눌러도 프로필 수정할 수 있게 해주세욥](https://app.asana.com/0/1202637499209292/1202637499209300/f) 작업했습니다.
- 마이페이지 이름 오른쪽 아이콘을 클릭했을 때만 수정하기 페이지로 이동하는데, 이름을 클릭해도 수정하기 페이지로 이동할 수 있도록 변경했습니다.

## 📑 작업 사항

- [x] 사용자 이름을 클릭해도 수정하기 페이지로 이동하도록 변경

## 🔎 기타