### PR TITLE
💄 [메인페이지] 피드백 버튼 위치 수정

### DIFF
--- a/components/button/FloatingBtn.tsx
+++ b/components/button/FloatingBtn.tsx
@@ -18,7 +18,7 @@ function FloatingBtn() {
 const BtnWrap = styled.div`
   position: fixed;
   bottom: 75px;
-  width: min(43.2rem, calc(100% - 4.8rem));
+  width: min(414px, calc(100% - 12.8%));
   text-align: right;
 `;
 


### PR DESCRIPTION
## 💡 개요

- 피드백 버튼 위치 수정했습니다.
- 우측 여백 값을 기준으로 정하면 푸터와 정렬이 안 되는 거 같아서 푸터를 기준으로 수정했습니다.

1. 피그마
![image](https://user-images.githubusercontent.com/48766355/182356362-0259a2a5-dadf-456d-a526-20732440722c.png)

2. 우측 여백 값 기준 정렬
![image](https://user-images.githubusercontent.com/48766355/182356375-77247b69-61c4-4a99-8b48-74c7ab1fca39.png)

3. 푸터 기준 정렬 (현재 적용 내용)
![image](https://user-images.githubusercontent.com/48766355/182356405-bc736e0b-9447-4345-8b69-6990dcf86be9.png)

## 📑 작업 사항

## 🔎 기타