### PR TITLE
🐛 [로그아웃] user data invalidate 설정

### DIFF
--- a/apis/user.ts
+++ b/apis/user.ts
@@ -38,7 +38,10 @@ const postUserLogOut = async () => {
 };
 
 const usePostUserLogOut = () => {
-  return useMutation(user.logout(), () => postUserLogOut());
+  const queryClient = useQueryClient();
+  return useMutation(user.logout(), () => postUserLogOut(), {
+    onSuccess: () => queryClient.invalidateQueries('user'),
+  });
 };
 
 const patchUserName = async (userName: string) => {
@@ -67,7 +70,7 @@ const patchUserImg = async (userImg: string) => {
 const usePatchUserImg = (userImg: string) => {
   const queryClient = useQueryClient();
   return useMutation(user.updateImg(userImg), () => patchUserImg(userImg), {
-    onSuccess: () => queryClient.invalidateQueries(user.information()),
+    onSuccess: () => queryClient.invalidateQueries('user'),
   });
 };
 


### PR DESCRIPTION
## 💡 개요

- 로그아웃 후 리액트 쿼리의 cache 값으로 사용자 정보가 남아있는 것을 해결하기 위해 invalidate 설정했습니다.

## 📑 작업 사항

- [x] 로그아웃 후 사용자 정보 invalidate 설정

## 🔎 기타