### PR TITLE
🐛 [마이페이지] 로그인 여부 체크 조건 업데이트

### DIFF
--- a/pages/user/mypage.tsx
+++ b/pages/user/mypage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { getCookie } from 'cookies-next';
 import { Mixpanel } from 'mixpanel';
 
 import { useGetUserInformation } from '@apis/user';
@@ -25,13 +26,15 @@ function MyPage() {
     setIsSSR(false);
   }, []);
 
+  const accessToken = getCookie('Access');
+
   const { data: profile } = useGetUserInformation();
 
   const [isSignIn, setIsSignIn] = useState(false);
 
   useEffect(() => {
-    profile && setIsSignIn(true);
-  }, [profile]);
+    accessToken && profile && setIsSignIn(true);
+  }, [accessToken, profile]);
 
   return (
     <>


### PR DESCRIPTION
## 💡 개요

- 사용자 로그인 여부를 쿠키의 토큰 값으로 확인했을 때 버그를 state 값으로 해결하고 (관련 PR [1](https://github.com/depromeet/antoon_web/pull/199), [2](https://github.com/depromeet/antoon_web/pull/205))
- 로컬 환경에서는 버그가 발생하지 않지만 배포 환경에서 버그가 발생하는 것을 해결하기 위한 작업입니다.
- 현재 배포 환경에서는 쿠키에 토큰 값이 없어도 사용자 data 가져오기에 성공했다는 결과는 보여주고 있습니다 🤔
- 이를 해결하기 위해 쿠키의 토큰 값, 사용자 데이터 두 개의 조건으로 로그인 여부를 확인하는 것으로 업데이트했습니다.

## 📑 작업 사항

- [x] 사용자 로그인 여부 체크 조건 업데이트

## 🔎 기타