### PR TITLE
🔧 [프로젝트 세팅] github actions dependencies cache 체크 변경

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -9,28 +9,32 @@ env:
 
 jobs:
     job_install_dependencies:
-        name: Intsall dependencies
+        name: Install dependencies
         runs-on: ubuntu-latest
 
         steps:
             - name: Checkout current commit (${{ github.sha }})
               uses: actions/checkout@v3
 
+            - name: Compute dependencies hash key
+              id: compute_lockfile_hash
+              run: echo "::set-output name=key::${{ hashFiles('**/yarn.lock') }}"
+
             - name: Restore dependencies
               id: restore_dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
-                  path: ${{ env.CACHED_DEPENDENCY_PATH }}
-                  key: dependencies-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      dependencies
+                path: ${{ env.CACHED_DEPENDENCY_PATH }}
+                key: dependencies-${{ runner.os }}-yarn-${{ steps.compute_lockfile_hash.outputs.key }}
+                restore-keys: |
+                  dependencies-${{ runner.os }}-yarn-
 
             - name: Install Dependencies
               if: steps.restore_dependencies.outputs.cache-hit != 'true'
               run: yarn
             
         outputs:
-            dependencies_cache_key: dependencies-${{ steps.compute_lockfile_hash.outputs.key }}
+            dependencies_cache_key: dependencies-${{ runner.os }}-yarn-${{ steps.compute_lockfile_hash.outputs.key }}
 
     job_lint:
         name: Lint
@@ -42,7 +46,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Check dependencies cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ env.CACHED_DEPENDENCY_PATH }}
                   key: ${{ needs.job_install_dependencies.outputs.dependencies_cache_key }}
@@ -62,14 +66,14 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Check dependencies cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ env.CACHED_DEPENDENCY_PATH }}
                   key: ${{ needs.job_install_dependencies.outputs.dependencies_cache_key }}
 
             - name: Restore bundle
               id: restore_bundle
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ env.CACHED_BUILD_PATH }}
                   key: build-${{ env.BUILD_CACHE_KEY }}-${{ github.ref_name }}
@@ -93,13 +97,13 @@ jobs:
           uses: actions/checkout@v3
 
         - name: Check dependencies cache
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
               path: ${{ env.CACHED_DEPENDENCY_PATH }}
               key: ${{ needs.job_install_dependencies.outputs.dependencies_cache_key }}
 
         - name: Check bundle cache
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ${{ env.CACHED_BUILD_PATH }}
             key: build-${{ env.BUILD_CACHE_KEY }}-${{ github.ref_name }}
@@ -132,7 +136,7 @@ jobs:
             fetch-depth: 0
 
         - name: Check dependencies cache
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
               path: ${{ env.CACHED_DEPENDENCY_PATH }}
               key: ${{ needs.job_install_dependencies.outputs.dependencies_cache_key }}

--- a/.github/workflows/deploy_stg_and_prd.yml
+++ b/.github/workflows/deploy_stg_and_prd.yml
@@ -14,28 +14,32 @@ env:
 
 jobs:
     job_install_dependencies:
-        name: Intsall dependencies
+        name: Install dependencies
         runs-on: ubuntu-latest
 
         steps:
             - name: Checkout current commit (${{ github.sha }})
               uses: actions/checkout@v3
 
+            - name: Compute dependencies hash key
+              id: compute_lockfile_hash
+              run: echo "::set-output name=key::${{ hashFiles('**/yarn.lock') }}"
+
             - name: Restore dependencies
               id: restore_dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
-                  path: ${{ env.CACHED_DEPENDENCY_PATH }}
-                  key: dependencies-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      dependencies
+                path: ${{ steps.yarn_cache_dir_path.outputs.dir }}
+                key: dependencies-${{ runner.os }}-yarn-${{ steps.compute_lockfile_hash.outputs.key }}
+                restore-keys: |
+                  dependencies-${{ runner.os }}-yarn-
 
             - name: Install Dependencies
               if: steps.restore_dependencies.outputs.cache-hit != 'true'
               run: yarn
             
         outputs:
-            dependencies_cache_key: dependencies-${{ steps.compute_lockfile_hash.outputs.key }}
+            dependencies_cache_key: dependencies-${{ runner.os }}-yarn-${{ steps.compute_lockfile_hash.outputs.key }}
 
     job_lint:
         name: Lint
@@ -47,7 +51,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Check dependencies cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ env.CACHED_DEPENDENCY_PATH }}
                   key: ${{ needs.job_install_dependencies.outputs.dependencies_cache_key }}
@@ -67,19 +71,20 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Check dependencies cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ env.CACHED_DEPENDENCY_PATH }}
                   key: ${{ needs.job_install_dependencies.outputs.dependencies_cache_key }}
 
             - name: Restore bundle
               id: restore_bundle
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ env.CACHED_BUILD_PATH }}
                   key: build-${{ env.BUILD_CACHE_KEY }}-${{ github.ref_name }}
                   restore-keys: |
                       build
+
             - name: Build STG bundle
               if: steps.restore_bundle.outputs.cache-hit == 'false' && github.ref == 'refs/heads/main'
               run: |
@@ -87,6 +92,7 @@ jobs:
                   ${{ secrets.ENV_STG }}
                   EOF
                   yarn build
+
             - name: Build PRD bundle
               if: steps.restore_bundle.outputs.cache-hit == 'false' && github.ref_type == 'tag'
               run: |
@@ -105,13 +111,13 @@ jobs:
           uses: actions/checkout@v3
 
         - name: Check dependencies cache
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
               path: ${{ env.CACHED_DEPENDENCY_PATH }}
               key: ${{ needs.job_install_dependencies.outputs.dependencies_cache_key }}
 
         - name: Check bundle cache
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ${{ env.CACHED_BUILD_PATH }}
             key: build-${{ env.BUILD_CACHE_KEY }}-${{ github.ref_name }}
@@ -153,7 +159,7 @@ jobs:
             fetch-depth: 0
 
         - name: Check dependencies cache
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
               path: ${{ env.CACHED_DEPENDENCY_PATH }}
               key: ${{ needs.job_install_dependencies.outputs.dependencies_cache_key }}


### PR DESCRIPTION
## 💡 개요
https://github.com/depromeet/antoon_web/pull/200

이전 pr에서 ci/cd 변경 후 디펜던시를 제대로 불러오지 못 하는 것 같아 디펜던시 캐시 체크 변경


## 📑 작업 사항

- [x] actions/cache v3로 업그레이드
  - https://github.com/actions/cache/blob/main/examples.md#node---yarn