### PR TITLE
🐛 [헤더] URL 공유 쿼리 스트링 수정

### DIFF
--- a/components/layout/Header/BackButton.tsx
+++ b/components/layout/Header/BackButton.tsx
@@ -3,11 +3,11 @@ import { useRouter } from 'next/router';
 
 import BackIcon from '@assets/icons/BackIcon';
 
-type BackBtnProps = {
+type BackButtonProps = {
   isHeaderPainted: boolean;
 };
 
-function BackBtn({ isHeaderPainted }: BackBtnProps) {
+function BackButton({ isHeaderPainted }: BackButtonProps) {
   const router = useRouter();
   const path = router.asPath;
   const isShared = path.includes('shared');
@@ -19,4 +19,4 @@ function BackBtn({ isHeaderPainted }: BackBtnProps) {
   );
 }
 
-export default BackBtn;
+export default BackButton;

--- a/components/layout/Header/HeaderLeftMenu.tsx
+++ b/components/layout/Header/HeaderLeftMenu.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 
 import LogoIcon from '@assets/icons/LogoIcon';
 
-import BackBtn from '@components/button/BackBtn';
+import BackButton from './BackButton';
 
 import { LeftWrap } from './HeaderLeftMenu.style';
 
@@ -24,7 +24,7 @@ function HeaderLeftMenu({
           <LogoIcon />
         </button>
       ) : headerLeft === '뒤로가기' ? (
-        <BackBtn isHeaderPainted={isHeaderPainted} />
+        <BackButton isHeaderPainted={isHeaderPainted} />
       ) : headerLeft === '없음' ? (
         <></>
       ) : (

--- a/components/layout/Header/HeaderRightMenu.tsx
+++ b/components/layout/Header/HeaderRightMenu.tsx
@@ -2,8 +2,9 @@ import Link from 'next/link';
 
 import SearchIcon from '@assets/icons/SearchIcon';
 
+import ShareButton from './ShareButton';
+
 import { RightWrap } from './HeaderRightMenu.style';
-import ShareBtn from '@components/button/ShareBtn';
 
 type HeaderRight = '검색' | '공유하기' | '없음';
 
@@ -23,7 +24,7 @@ function HeaderRightMenu({
           </a>
         </Link>
       ) : headerRight === '공유하기' ? (
-        <ShareBtn isHeaderPainted={isHeaderPainted} />
+        <ShareButton isHeaderPainted={isHeaderPainted} />
       ) : headerRight === '없음' ? (
         <></>
       ) : (

--- a/components/layout/Header/ShareButton.tsx
+++ b/components/layout/Header/ShareButton.tsx
@@ -5,11 +5,11 @@ import ShareIcon from '@assets/icons/ShareIcon';
 
 import shareAPI from '@utils/shareAPI';
 
-type ShareBtnProps = {
+type ShareButtonProps = {
   isHeaderPainted: boolean;
 };
 
-function ShareBtn({ isHeaderPainted }: ShareBtnProps) {
+function ShareButton({ isHeaderPainted }: ShareButtonProps) {
   const router = useRouter();
   const path = router.asPath;
 
@@ -20,4 +20,4 @@ function ShareBtn({ isHeaderPainted }: ShareBtnProps) {
   );
 }
 
-export default ShareBtn;
+export default ShareButton;

--- a/domains/webtoon/detail/Comment.tsx
+++ b/domains/webtoon/detail/Comment.tsx
@@ -16,14 +16,14 @@ import {
 } from './Comment.style';
 
 import UserProfile from '@components/image/UserProfile';
-import FavoriteBtn from '@components/button/FavoriteBtn';
+import FavoriteButton from '@domains/webtoon/detail/FavoriteButton';
 import CommentTextInput from '@components/detail/commentTextInput/CommentTextInput';
 import OnError from '@components/OnError';
 import LoadingSpinner from '@components/spinner/LoadingSpinner';
 import ErrorBoundary from '@components/ErrorBoundary';
 
 import { useInView } from 'react-intersection-observer';
-import { CommentType, Comments, IComment } from '@_types/comments-type';
+import { CommentType, IComment } from '@_types/comments-type';
 import { useEffect, useState } from 'react';
 
 function Comment({
@@ -72,7 +72,7 @@ function Comment({
           commentType={commentType}
         />
         <>
-          {cmmts?.pages.map((page, index) => {
+          {cmmts?.pages.map((page) => {
             return page.data?.map((comment: IComment) => {
               return (
                 <CommentWrap key={comment.discussionId}>
@@ -84,7 +84,7 @@ function Comment({
                     </UserInfo>
                     <Content>{comment?.content}</Content>
                     <FavoriteWrap>
-                      <FavoriteBtn
+                      <FavoriteButton
                         isFavoriteChecked={comment.isUserLike}
                         type={commentType}
                         id={comment.discussionId}

--- a/domains/webtoon/detail/FavoriteBtn.stories.tsx
+++ b/domains/webtoon/detail/FavoriteBtn.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import FavoriteBtn from './FavoriteBtn';
+import FavoriteBtn from './FavoriteButton';
 
 export default {
   title: 'Components/Common/Button',

--- a/domains/webtoon/detail/FavoriteButton.tsx
+++ b/domains/webtoon/detail/FavoriteButton.tsx
@@ -15,7 +15,12 @@ type FavoriteProps = {
   isUser: boolean;
 };
 
-function FavoriteBtn({ isFavoriteChecked, type, id, isUser }: FavoriteProps) {
+function FavoriteButton({
+  isFavoriteChecked,
+  type,
+  id,
+  isUser,
+}: FavoriteProps) {
   const [isLiked, setIsLiked] = useState(isFavoriteChecked);
 
   const { fireToast } = useToast();
@@ -34,4 +39,4 @@ function FavoriteBtn({ isFavoriteChecked, type, id, isUser }: FavoriteProps) {
   return <HeartIcon fill={isLiked} onClickFavorite={onClickFavorite} />;
 }
 
-export default FavoriteBtn;
+export default FavoriteButton;

--- a/domains/webtoon/home/FeedbackButton.stories.tsx
+++ b/domains/webtoon/home/FeedbackButton.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import FloatingBtn from './FloatingBtn';
+import FloatingBtn from './FeedbackButton';
 
 export default {
   title: 'Components/Common/Button',

--- a/domains/webtoon/home/FeedbackButton.tsx
+++ b/domains/webtoon/home/FeedbackButton.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { EmailIcon } from '@assets/icons';
 
-function FloatingBtn() {
+function FeedbackButton() {
   return (
     <BtnWrap>
       <a
@@ -22,4 +22,4 @@ const BtnWrap = styled.div`
   text-align: right;
 `;
 
-export default FloatingBtn;
+export default FeedbackButton;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import { Mixpanel } from 'mixpanel';
 import Header from '@components/layout/Header/Header';
 import Modal from '@components/modal/onboard/Modal';
 import { default as _Home } from '@domains/webtoon/home/Home';
-import FloatingBtn from '@components/button/FloatingBtn';
+import FeedbackButton from '@domains/webtoon/home/FeedbackButton';
 import CoinModal from '@domains/user/signup/modal/CoinModal';
 
 const Home: NextPage = () => {
@@ -30,7 +30,7 @@ const Home: NextPage = () => {
       <Header headerLeft="로고" headerRight="검색" />
       <Modal />
       <_Home />
-      <FloatingBtn />
+      <FeedbackButton />
     </>
   );
 };

--- a/utils/shareAPI.ts
+++ b/utils/shareAPI.ts
@@ -1,9 +1,13 @@
 function shareAPI(path: string) {
+  const queryString = path.includes('?')
+    ? `${path}&shared=true`
+    : `${path}?shared=true`;
+
   if (navigator.share) {
     navigator
       .share({
         title: '개미는 툰툰 :: 웹툰의 새로운 덕질 문화',
-        url: `https://antoon.fun${path}&shared=true`,
+        url: `https://antoon.fun${queryString}`,
       })
       .catch(console.error);
   } else {


### PR DESCRIPTION
## 💡 개요

- [✨ [헤더] URL 공유하기 버튼](https://github.com/depromeet/antoon_web/pull/215) 버그 수정했습니다.
- [커플 카테고리](https://antoon.fun/community/character/39?category=%EC%BB%A4%ED%94%8C)처럼 기존에 쿼리 스트링이 있는 경우 `&shared=true`로 값을 추가하고
- [웹툰 상세 페이지](https://antoon.fun/webtoon/563)처럼 쿼리 스트링이 없는 경우는 `?shared=true`로 추가해야 해서
- 현재 URL에 쿼리 스트링이 존재하는지 확인하는 로직을 추가했습니다.
- 버그 픽스하면서 버튼 컴포넌트를 같은 기능의 폴더로 이동하고, 파일명을 수정하는 리팩토링도 진행했습니다.
- 현재 같은 기능을 하는 컴포넌트들이 각자 다른 폴더로 흩뿌려져 있다고 느껴 수정했습니다.

## 📑 작업 사항

- [x] 공유하기 버그 픽스
- [x] 버튼 컴포넌트 리팩토링

## 🔎 기타